### PR TITLE
Update recognized python versions 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "venvipy"
+dynamic = ["version"]
+
 authors = [
     {name = "sinusphi", email = "sinusphi.sq@gmail.com"}
 ]
@@ -42,6 +44,9 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython"
 ]
 dependencies = [
@@ -50,8 +55,11 @@ dependencies = [
     "beautifulsoup4",
     'dataclasses ; python_version<"3.7"'
 ]
-dynamic = ["0.3.7"]
 
 [project.scripts]
 venvipy = "venvipy.venvi:main"
 venvipy-wizard = "venvipy.wizard:main"
+
+[tool.setuptools]
+packages = ["venvipy"]
+dynamic = {version = {attr = "venvipy.get_data.__version__"}}

--- a/venvipy/get_data.py
+++ b/venvipy/get_data.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass
 from bs4 import BeautifulSoup
 import requests
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"
 
 CFG_DIR = os.path.expanduser("~/.venvipy")
 DB_FILE = os.path.expanduser("~/.venvipy/py-installs")

--- a/venvipy/get_data.py
+++ b/venvipy/get_data.py
@@ -139,7 +139,7 @@ def get_python_installs(relaunching=False):
     a new database if `relaunching=True`.
     """
     versions = [
-        "3.11", "3.10", "3.9", "3.8", "3.7", "3.6", "3.5", "3.4", "3.3"
+        "3.14", "3.13", "3.12", "3.11", "3.10", "3.9", "3.8", "3.7", "3.6", "3.5", "3.4", "3.3"
     ]
     py_info_list = []
     ensure_confdir()

--- a/venvipy/wizard.py
+++ b/venvipy/wizard.py
@@ -395,6 +395,7 @@ class BasicSettings(QWizardPage):
                 python3.3 python3.4 python3.5 \
                 python3.6 python3.7 python3.8 \
                 python3.9 python3.10 python3.11 \
+                python3.12 python3.13 python3.14
             )"
         )
         bin_file = file_name[0]

--- a/venvipy/wizard.py
+++ b/venvipy/wizard.py
@@ -395,7 +395,7 @@ class BasicSettings(QWizardPage):
                 python3.3 python3.4 python3.5 \
                 python3.6 python3.7 python3.8 \
                 python3.9 python3.10 python3.11 \
-                python3.12 python3.13 python3.14
+                python3.12 python3.13 python3.14 \
             )"
         )
         bin_file = file_name[0]


### PR DESCRIPTION
Lazily patches an issue where modern python versions (e.g. 3.14, 3.13, & 3.12) weren't recognized as valid. Ideally, the program could check an online list of valid python versions so that there wouldn't need to be manual fixes every year or so, but that's more than I feel like doing (especially because https://endoflife.date/python doesn't include pre-release versions).

