### PR TITLE
Add platform adapter and run pip/venv via venv Python

### DIFF
--- a/venvipy/get_data.py
+++ b/venvipy/get_data.py
@@ -29,11 +29,13 @@ import sqlite3
 import logging
 from pathlib import Path
 from typing import List, Optional
-from subprocess import Popen, PIPE
+from subprocess import PIPE, STDOUT, run
 from dataclasses import dataclass
 
 from bs4 import BeautifulSoup
 import requests
+
+from platforms import get_platform
 
 __version__ = "0.3.8"
 
@@ -69,7 +71,11 @@ def to_version(value):
 def to_path(bin_path, version):
     """Return the absolute path to a python binary.
     """
-    return os.path.join(bin_path, f"python{version}")
+    platform = get_platform()
+    base_path = Path(bin_path)
+    if platform.is_windows():
+        return str(base_path / platform.python_exe_name())
+    return str(base_path / f"{platform.python_exe_name()}{version}")
 
 
 def is_writable(target_dir):
@@ -133,10 +139,17 @@ def ensure_active_venv():
 def get_python_version(py_path):
     """Return Python version.
     """
-    with Popen([py_path, "-V"], stdout=PIPE, encoding="utf-8") as res:
-        out, _ = res.communicate()
+    res = run(
+        [py_path, "-V"],
+        stdout=PIPE,
+        stderr=STDOUT,
+        encoding="utf-8",
+        errors="replace",
+        text=True,
+        check=False,
+    )
 
-    python_version = out.strip()
+    python_version = (res.stdout or "").strip()
     return python_version
 
 
@@ -148,6 +161,7 @@ def get_python_installs(relaunching=False):
     LATEST = 15
     versions = [f"3.{v}" for v in range(LATEST, 2, -1)]
     py_info_list = []
+    platform = get_platform()
 
     ensure_confdir()
 
@@ -162,9 +176,9 @@ def get_python_installs(relaunching=False):
             )
             writer.writeheader()
 
-            for i, version in enumerate(versions):
-                python_path = shutil.which(f"python{version}")
-                if python_path is not None:
+            if platform.is_windows():
+                python_paths = _get_windows_python_paths()
+                for python_path in python_paths:
                     python_version = get_python_version(python_path)
                     py_info = PythonInfo(python_version, python_path)
                     py_info_list.append(py_info)
@@ -172,6 +186,17 @@ def get_python_installs(relaunching=False):
                         "PYTHON_VERSION": py_info.py_version,
                         "PYTHON_PATH": py_info.py_path
                     })
+            else:
+                for version in versions:
+                    python_path = shutil.which(f"python{version}")
+                    if python_path is not None:
+                        python_version = get_python_version(python_path)
+                        py_info = PythonInfo(python_version, python_path)
+                        py_info_list.append(py_info)
+                        writer.writerow({
+                            "PYTHON_VERSION": py_info.py_version,
+                            "PYTHON_PATH": py_info.py_path
+                        })
 
             cf.close()
 
@@ -182,6 +207,50 @@ def get_python_installs(relaunching=False):
 
         return py_info_list[::-1]
     return False
+
+
+def _get_windows_python_paths():
+    paths = []
+    py_launcher = run(
+        ["py", "-0p"],
+        stdout=PIPE,
+        stderr=STDOUT,
+        encoding="utf-8",
+        errors="replace",
+        text=True,
+        check=False,
+    )
+    if py_launcher.returncode == 0:
+        for line in py_launcher.stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split()
+            candidate = parts[-1] if parts else ""
+            if candidate and os.path.exists(candidate):
+                paths.append(candidate)
+
+    if not paths:
+        where_python = run(
+            ["where", "python"],
+            stdout=PIPE,
+            stderr=STDOUT,
+            encoding="utf-8",
+            errors="replace",
+            text=True,
+            check=False,
+        )
+        if where_python.returncode == 0:
+            for line in where_python.stdout.splitlines():
+                candidate = line.strip()
+                if candidate and os.path.exists(candidate):
+                    paths.append(candidate)
+
+    unique_paths = []
+    for path in paths:
+        if path not in unique_paths:
+            unique_paths.append(path)
+    return unique_paths
 
 
 def add_python(py_path):
@@ -757,32 +826,19 @@ def get_package_infos(pkg: str) -> list[PackageInfo]:
 def get_installed_packages(venv_location, venv_name) -> list:
     """Get infos about installed packages.
     """
-    # build path to venv
-    venv_path = os.path.join(venv_location, venv_name)
-
-    # path to 'lib' folder
-    lib_dir = os.path.join(venv_path, "lib")
-
-    # list content
-    lib_dir_content = os.listdir(lib_dir)
-
-    # get 'python' folder
-    python_dir = lib_dir_content[0]
-
-    # build path to 'site-packages' folder
-    site_packages_dir = os.path.join(lib_dir, python_dir, "site-packages")
+    platform = get_platform()
+    venv_path = Path(venv_location) / venv_name
+    site_packages_dir = platform.site_packages_path(venv_path)
 
     # get list of installed packages
     package_info_list = []
+    if not site_packages_dir.exists():
+        return package_info_list
     site_packages = os.listdir(site_packages_dir)
 
     for pkg in site_packages:
         if ".dist-info" in pkg:
-            meta_file = os.path.join(
-                site_packages_dir,
-                pkg,
-                "METADATA"
-            )
+            meta_file = site_packages_dir / pkg / "METADATA"
 
             try:
                 with open(meta_file, "r", encoding="utf-8") as f:

--- a/venvipy/manage_pip.py
+++ b/venvipy/manage_pip.py
@@ -20,11 +20,14 @@
 This module manages all pip processes.
 """
 import os
+import shlex
 import logging
+from pathlib import Path
 
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, QProcess
 from PyQt5.QtWidgets import QApplication
 
+from platforms import get_platform
 
 logger = logging.getLogger(__name__)
 
@@ -33,21 +36,6 @@ logger = logging.getLogger(__name__)
 #]===========================================================================[#
 #] INSTALL SELECTED PACKAGES [#==============================================[#
 #]===========================================================================[#
-
-def has_bash():
-    """
-    Test if bash is available.
-    """
-    process = QProcess()
-    process.start("which bash")
-    process.waitForStarted()
-    process.waitForFinished()
-
-    if process.exitStatus() == QProcess.NormalExit:
-        return bool(process.readAll())
-
-    return False
-
 
 class PipManager(QObject):
     """
@@ -88,24 +76,21 @@ class PipManager(QObject):
 
     def run_pip(self, command="", options=None):
         """
-        Activate the virtual environment and run pip commands.
+        Run pip commands using the virtual environment interpreter.
         """
-        if has_bash():
-            if options is None:
-                options = []
+        if options is None:
+            options = []
 
-            venv_path = os.path.join(self._venv_dir, self._venv_name)
-            pip = f"pip {command} {' '.join(options)}"
-            pipdeptree = f"pipdeptree {' '.join(options)}"
+        venv_path = Path(self._venv_dir) / self._venv_name
+        platform = get_platform()
+        venv_python = platform.venv_python_path(venv_path)
 
-            task = pipdeptree if command == "pipdeptree" else pip
+        if command == "pipdeptree":
+            args = ["-m", "pipdeptree"] + options
+        else:
+            args = ["-m", "pip"] + shlex.split(command) + options
 
-            script = (
-                f"source {venv_path}/bin/activate;"
-                f"{task};"
-                "deactivate;"
-            )
-            self._process.start("bash", ["-c", script])
+        self._process.start(str(venv_python), args)
 
 
     def process_stop(self):
@@ -171,7 +156,7 @@ if __name__ == "__main__":
     manager.text_changed.connect(console.update_status)
     manager.started.connect(console.show)
     manager.run_pip(
-        "freeze", [f" > {current_dir}/{_venv_name}/requirements.txt"]
+        "freeze", ["--output", str(Path(current_dir) / _venv_name / "requirements.txt")]
     )
 
     sys.exit(app.exec_())

--- a/venvipy/pkg_installer.py
+++ b/venvipy/pkg_installer.py
@@ -22,6 +22,7 @@ This module contains the package installer.
 import os
 import logging
 import webbrowser
+from pathlib import Path
 
 from PyQt5.QtGui import (
     QIcon,
@@ -333,7 +334,7 @@ class PackageInstaller(QDialog):
 
             self.manager = PipManager(
                 self.venv_location,
-                f"'{self.venv_name}'"
+                self.venv_name
             )
             # open the console when recieving signal from manager
             self.manager.started.connect(self.console.exec_)
@@ -382,17 +383,17 @@ class PackageInstaller(QDialog):
         self.msg_box.exec_()
 
         if self.msg_box.clickedButton() == yes_button:
-            venv_dir = os.path.join(self.venv_location, self.venv_name)
+            venv_dir = Path(self.venv_location) / self.venv_name
             save_file = QFileDialog.getSaveFileName(
                 self,
                 "Save requirements",
-                directory=os.path.join(venv_dir, "requirements.txt")
+                directory=str(venv_dir / "requirements.txt")
             )
             save_path = save_file[0]
 
             if len(save_path) >= 1:
                 self.manager = PipManager(self.venv_location, self.venv_name)
-                self.manager.run_pip(creator.cmds[2], [">", save_path])
+                self.manager.run_pip(creator.cmds[2], ["--output", save_path])
                 logger.debug(f"Saved '{save_path}'")
 
                 QMessageBox.information(

--- a/venvipy/pkg_manager.py
+++ b/venvipy/pkg_manager.py
@@ -153,7 +153,7 @@ class PackagesTable(QTableView):
 
             self.manager = PipManager(
                 self.venv_location,
-                f"'{self.venv_name}'"
+                self.venv_name
             )
             # open the console when recieving signal from manager
             self.manager.started.connect(self.console.exec_)

--- a/venvipy/platforms/__init__.py
+++ b/venvipy/platforms/__init__.py
@@ -1,0 +1,34 @@
+#    VenviPy - A Virtual Environment Manager for Python.
+#    Copyright (C) 2021 - Youssef Serestou - sinusphi.sq@gmail.com
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License or any
+#    later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    A copy of the GNU General Public License version 3 named LICENSE is
+#    in the root directory of VenviPy.
+#    If not, see <https://www.gnu.org/licenses/licenses.en.html#GPL>.
+
+# -*- coding: utf-8 -*-
+"""
+Platform helpers for OS-specific behavior.
+"""
+import sys
+
+from .linux import LinuxPlatform
+from .windows import WindowsPlatform
+
+
+def get_platform():
+    if sys.platform.startswith("win"):
+        return WindowsPlatform()
+    return LinuxPlatform()
+
+
+__all__ = ["get_platform", "LinuxPlatform", "WindowsPlatform"]

--- a/venvipy/platforms/base.py
+++ b/venvipy/platforms/base.py
@@ -1,0 +1,60 @@
+#    VenviPy - A Virtual Environment Manager for Python.
+#    Copyright (C) 2021 - Youssef Serestou - sinusphi.sq@gmail.com
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License or any
+#    later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    A copy of the GNU General Public License version 3 named LICENSE is
+#    in the root directory of VenviPy.
+#    If not, see <https://www.gnu.org/licenses/licenses.en.html#GPL>.
+
+# -*- coding: utf-8 -*-
+"""
+Base platform abstraction.
+"""
+from pathlib import Path
+
+
+class Platform:
+    """Small OS abstraction layer."""
+    name = "base"
+
+    def is_windows(self):
+        return False
+
+    def is_linux(self):
+        return False
+
+    def venv_bin_dir_name(self):
+        return "bin"
+
+    def python_exe_name(self):
+        return "python"
+
+    def pip_exe_name(self):
+        return "pip"
+
+    def venv_python_path(self, venv_dir: Path) -> Path:
+        return venv_dir / self.venv_bin_dir_name() / self.python_exe_name()
+
+    def venv_pip_path(self, venv_dir: Path) -> Path:
+        return venv_dir / self.venv_bin_dir_name() / self.pip_exe_name()
+
+    def activate_script_path(self, venv_dir: Path) -> Path:
+        return venv_dir / self.venv_bin_dir_name() / "activate"
+
+    def default_python_search_path(self) -> str:
+        return str(Path.home())
+
+    def site_packages_path(self, venv_dir: Path) -> Path:
+        lib_dir = venv_dir / "lib"
+        if not lib_dir.exists():
+            lib_dir = venv_dir / "Lib"
+        return lib_dir / "site-packages"

--- a/venvipy/platforms/linux.py
+++ b/venvipy/platforms/linux.py
@@ -1,0 +1,41 @@
+#    VenviPy - A Virtual Environment Manager for Python.
+#    Copyright (C) 2021 - Youssef Serestou - sinusphi.sq@gmail.com
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License or any
+#    later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    A copy of the GNU General Public License version 3 named LICENSE is
+#    in the root directory of VenviPy.
+#    If not, see <https://www.gnu.org/licenses/licenses.en.html#GPL>.
+
+# -*- coding: utf-8 -*-
+"""
+Linux platform implementation.
+"""
+from .base import Platform
+
+
+class LinuxPlatform(Platform):
+    name = "linux"
+
+    def is_linux(self):
+        return True
+
+    def default_python_search_path(self) -> str:
+        return "/usr/local/bin"
+
+    def site_packages_path(self, venv_dir):
+        lib_dir = venv_dir / "lib"
+        if not lib_dir.exists():
+            return lib_dir / "site-packages"
+        python_dirs = [p for p in lib_dir.iterdir() if p.is_dir()]
+        if not python_dirs:
+            return lib_dir / "site-packages"
+        return python_dirs[0] / "site-packages"

--- a/venvipy/platforms/windows.py
+++ b/venvipy/platforms/windows.py
@@ -1,0 +1,49 @@
+#    VenviPy - A Virtual Environment Manager for Python.
+#    Copyright (C) 2021 - Youssef Serestou - sinusphi.sq@gmail.com
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License or any
+#    later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    A copy of the GNU General Public License version 3 named LICENSE is
+#    in the root directory of VenviPy.
+#    If not, see <https://www.gnu.org/licenses/licenses.en.html#GPL>.
+
+# -*- coding: utf-8 -*-
+"""
+Windows platform implementation.
+"""
+from pathlib import Path
+
+from .base import Platform
+
+
+class WindowsPlatform(Platform):
+    name = "windows"
+
+    def is_windows(self):
+        return True
+
+    def venv_bin_dir_name(self):
+        return "Scripts"
+
+    def python_exe_name(self):
+        return "python.exe"
+
+    def pip_exe_name(self):
+        return "pip.exe"
+
+    def activate_script_path(self, venv_dir: Path) -> Path:
+        return venv_dir / self.venv_bin_dir_name() / "activate.bat"
+
+    def default_python_search_path(self) -> str:
+        return str(Path.home())
+
+    def site_packages_path(self, venv_dir: Path) -> Path:
+        return venv_dir / "Lib" / "site-packages"


### PR DESCRIPTION
### Motivation
- Provide a small OS abstraction to centralize differences between Linux and Windows venv layouts and executable names for reliable cross-platform behavior.
- Stop relying on shell activation and `bash`-specific workflows by invoking the virtual environment's interpreter directly for pip and venv operations.
- Replace fragile path string handling and shell redirection with `pathlib`-based paths and explicit argument lists to reduce quoting/shell-escaping bugs.
- Improve Python discovery and site-packages lookup on Windows to better detect interpreters and installed packages.

### Description
- Add a `venvipy.platforms` package with `base.py`, `linux.py`, `windows.py` and `get_platform()` providing helpers like `venv_python_path`, `venv_bin_dir_name`, `python_exe_name`, and `site_packages_path`.
- Refactor `PipManager` to execute the venv Python directly (`-m pip` / `-m pipdeptree`) using `QProcess` argument lists instead of sourcing activation scripts.
- Replace shell-based venv creation with `create_venv()` using `subprocess.run` and `pathlib.Path`, and update callers (`creator.py`, `tables.py`, `wizard.py`, `pkg_installer.py`, `pkg_manager.py`, `manage_pip.py`) to use platform helpers and remove quoted venv/name strings.
- Improve Python discovery and installed-package inspection in `get_data.py` by adding Windows probes (`py -0p`, `where python`) and using the platform adapter to find `site-packages`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965cf5113548320b01a319337ad0b01)